### PR TITLE
Fix yarn install and building steps, otherwise they failed when you start from scratch

### DIFF
--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -32,7 +32,7 @@
     "build:prod": "yarn run install-rise-reveal && tsc -b",
     "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
-    "install-rise-reveal": "cp -r ../../node_modules/rise-reveal/export/reveal.js/plugin/chalkboard/img/ ../../node_modules/rise-reveal/export/reveal.js/plugin/notes/notes.html ../../rise/static/",
+    "install-rise-reveal": "mkdir -p ../../rise/static; cp -r ../rise-reveal/export/reveal.js/plugin/chalkboard/img/ ../rise-reveal/export/reveal.js/plugin/notes/notes.html ../../rise/static/",
     "watch": "tsc -b --watch --preserveWatchOutput"
   },
   "dependencies": {

--- a/packages/rise-reveal/package.json
+++ b/packages/rise-reveal/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "[ ! -d \"export\" ] && npm install && for target in copy patch; do npm run $target; done || echo Patched rise-reveal exists - skipping build",
-    "copy": "mkdir -p export; cp -r node_modules/reveal.js/ ./export/reveal.js/; cp -r node_modules/reveal.js-plugins/chalkboard/ ./export/reveal.js/plugin",
+    "copy": "mkdir -p export; cp -r node_modules/reveal.js/ ./export/reveal.js/; cp -r node_modules/reveal.js-plugins/chalkboard/ ./export/reveal.js/plugin/chalkboard/",
     "patch": "for target in patch-reveal-css patch-notes patch-themes patch-chalkboard ; do npm run $target; done",
     "patch-reveal-css": "sed -i.upstream '11 s_^_/*_' export/reveal.js/css/reveal.css",
     "patch-notes": "bash patch-notes-plugin.sh",


### PR DESCRIPTION
Some things I was surprised about...

1. After doing the yarn install, all the JS on rise-reveal was "moved" from node_modules into the export directory.
Since we are using cp -r, I was surprised to find the node_modules inside rise-reveal empty...

2. I guess the images from the chalkboard and the html file from the notes need to be copied over explicitly because they are not JS/CSS files, correct?

Again, thanks for working on this port!!