### PR TITLE
fix speaker notes

### DIFF
--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -511,7 +511,9 @@ namespace Rise {
         // Notes are wrapped in an <aside> element
         const aside = document.createElement('aside');
         aside.classList.add('notes');
-        subslide_section.appendChild(cell_node);
+        aside.append(cell_node);
+        subslide_section.appendChild(aside)
+      
       } else {
         current_fragment.appendChild(cell_node);
       }


### PR DESCRIPTION
In the Speaker notes view, the Notes cell does not appear in the Notes section, and the Notes cell is not hidden in the current Slideshow. Also, the Notes-only layout didn't show the notes. I checked the Binder demo, and the speaker notes do not work there either.