### PR TITLE
Fix toggle all RISE buttons on slides

### DIFF
--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -844,7 +844,7 @@ namespace Rise {
       const element = document.querySelector(selector) as HTMLElement | null;
       if (element) {
         element.style.visibility =
-          element.style.visibility === 'true' ? 'false' : 'true';
+          element.style.visibility === 'hidden' ? 'visible': 'hidden';
       }
     }
   }
@@ -954,9 +954,9 @@ namespace Rise {
         79: null, // o disabled
         80: null, // p, up disabled
         84: null, // t, modified in the custom notes plugin.
-        87: null // w, toggle overview
+        87: null, // w, toggle overview
         // is it ok?
-        // 188: toggleAllRiseButtons // comma
+        188: toggleAllRiseButtons // comma, hard-wired to toggleAllRiseButtons
       }
     };
 


### PR DESCRIPTION
Fix toggle all RISE buttons and hard-wire both keyboards "m" and "," to hide/show buttons on the slideshow.